### PR TITLE
Include processing of file & assembly versions

### DIFF
--- a/LocalAdmin V2.csproj
+++ b/LocalAdmin V2.csproj
@@ -29,6 +29,8 @@
     <PropertyGroup>
         <!-- Disable automatic generation of version attribute -->
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/LocalAdmin V2.csproj
+++ b/LocalAdmin V2.csproj
@@ -29,8 +29,8 @@
     <PropertyGroup>
         <!-- Disable automatic generation of version attribute -->
         <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
-		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/Properties/VersionInfo.cs
+++ b/Properties/VersionInfo.cs
@@ -1,3 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyInformationalVersion(LocalAdmin.V2.Core.LocalAdmin.VersionString)]
+[assembly: AssemblyFileVersion(LocalAdmin.V2.Core.LocalAdmin.VersionString)]
+[assembly: AssemblyVersion(LocalAdmin.V2.Core.LocalAdmin.VersionString)]


### PR DESCRIPTION
Up to this point the file and assembly version was not included in the attributes and was `1.0.0.0`.