### PR TITLE
Introduced log limits

### DIFF
--- a/Core/LocalAdmin.cs
+++ b/Core/LocalAdmin.cs
@@ -56,6 +56,8 @@ namespace LocalAdmin.V2.Core
         private static bool _ignoreNextRestart;
         private static readonly Stopwatch RestartsStopwatch = new Stopwatch();
 
+        internal static ulong LogLengthLimit = 25000000000, LogEntriesLimit = 10000000000; 
+
         internal static Config? Configuration;
 
         internal ShutdownAction ExitAction = ShutdownAction.Crash;
@@ -76,7 +78,9 @@ namespace LocalAdmin.V2.Core
             LaLogsPath,
             GameLogsPath,
             RestartsLimit,
-            RestartsTimeWindow
+            RestartsTimeWindow,
+            LogLengthLimit,
+            LogEntriesLimit
         }
 
         internal LocalAdmin()
@@ -247,6 +251,14 @@ namespace LocalAdmin.V2.Core
                                         case "--restartsTimeWindow":
                                             capture = CaptureArgs.RestartsTimeWindow;
                                             break;
+                                        
+                                        case "--logLengthLimit":
+                                            capture = CaptureArgs.LogLengthLimit;
+                                            break;
+                                        
+                                        case "--logEntriesLimit":
+                                            capture = CaptureArgs.LogEntriesLimit;
+                                            break;
 
                                         case "--":
                                             capture = CaptureArgs.ArgsPassthrough;
@@ -289,6 +301,42 @@ namespace LocalAdmin.V2.Core
                                     ConsoleUtil.WriteLine("restartsTimeWindow argument value must be an integer greater or equal to 0.", ConsoleColor.Red);
                                 }
                                 capture = CaptureArgs.None;
+                                break;
+
+                            case CaptureArgs.LogLengthLimit:
+                            {
+                                string a = arg.Replace("k", "000", StringComparison.Ordinal)
+                                    .Replace("M", "000000", StringComparison.Ordinal)
+                                    .Replace("G", "000000000", StringComparison.Ordinal)
+                                    .Replace("T", "000000000000", StringComparison.Ordinal);
+                                if (!ulong.TryParse(a, out LogLengthLimit))
+                                {
+                                    ConsoleUtil.WriteLine(
+                                        "logLengthLimit argument value must be an integer greater or equal to 0.",
+                                        ConsoleColor.Red);
+                                    LogLengthLimit = 25000000000;
+                                }
+
+                                capture = CaptureArgs.None;
+                            }
+                                break;
+
+                            case CaptureArgs.LogEntriesLimit:
+                            {
+                                string a = arg.Replace("k", "000", StringComparison.Ordinal)
+                                    .Replace("M", "000000", StringComparison.Ordinal)
+                                    .Replace("G", "000000000", StringComparison.Ordinal)
+                                    .Replace("T", "000000000000", StringComparison.Ordinal);
+                                if (!ulong.TryParse(a, out LogEntriesLimit))
+                                {
+                                    ConsoleUtil.WriteLine(
+                                        "logEntriesLimit argument value must be an integer greater or equal to 0.",
+                                        ConsoleColor.Red);
+                                    LogEntriesLimit = 10000000000;
+                                }
+
+                                capture = CaptureArgs.None;
+                            }
                                 break;
 
                             default:

--- a/IO/Logging/Logger.cs
+++ b/IO/Logging/Logger.cs
@@ -70,14 +70,14 @@ namespace LocalAdmin.V2.IO.Logging
                 if (_totalEntries > Core.LocalAdmin.LogEntriesLimit && Core.LocalAdmin.LogEntriesLimit > 0)
                 {
                     _logging = false;
-                    AppendLog("Log entries limit exceeded. Logging Stopped.", bypass: true);
+                    AppendLog($"{ConsoleUtil.GetLogsTimestamp()} Log entries limit exceeded. Logging stopped.", bypass: true);
                     EndLogging(true);
                 }
                 
                 if (_totalLength > Core.LocalAdmin.LogLengthLimit && Core.LocalAdmin.LogLengthLimit > 0)
                 {
                     _logging = false;
-                    AppendLog("Log length limit exceeded. Logging Stopped.", bypass: true);
+                    AppendLog($"{ConsoleUtil.GetLogsTimestamp()} Log length limit exceeded. Logging stopped.", bypass: true);
                     EndLogging(true);
                 }
             }

--- a/IO/Logging/Logger.cs
+++ b/IO/Logging/Logger.cs
@@ -32,10 +32,10 @@ namespace LocalAdmin.V2.IO.Logging
             Log($"{ConsoleUtil.GetLogsTimestamp()} Timezone offset: {DateTimeOffset.Now:zzz}");
         }
 
-        public static void EndLogging()
+        public static void EndLogging(bool bypass = false)
         {
-            if (!_logging) return;
-            Log($"{ConsoleUtil.GetLogsTimestamp()} --- END OF LOG ---", true);
+            if (!_logging && !bypass) return;
+            AppendLog($"{ConsoleUtil.GetLogsTimestamp()} --- END OF LOG ---", true, true);
 
             _logging = false;
             _sb = null;
@@ -43,7 +43,7 @@ namespace LocalAdmin.V2.IO.Logging
 
         private static void AppendLog(string text, bool flush = false, bool bypass = false)
         {
-            if (!_logging) return;
+            if (!_logging && !bypass) return;
             
             try
             {
@@ -69,14 +69,16 @@ namespace LocalAdmin.V2.IO.Logging
 
                 if (_totalEntries > Core.LocalAdmin.LogEntriesLimit && Core.LocalAdmin.LogEntriesLimit > 0)
                 {
+                    _logging = false;
                     AppendLog("Log entries limit exceeded. Logging Stopped.", bypass: true);
-                    EndLogging();
+                    EndLogging(true);
                 }
                 
                 if (_totalLength > Core.LocalAdmin.LogLengthLimit && Core.LocalAdmin.LogLengthLimit > 0)
                 {
+                    _logging = false;
                     AppendLog("Log length limit exceeded. Logging Stopped.", bypass: true);
-                    EndLogging();
+                    EndLogging(true);
                 }
             }
             catch (Exception e)
@@ -84,7 +86,7 @@ namespace LocalAdmin.V2.IO.Logging
                 Console.Write("Failed to write log: " + e.Message);
             }
         }
-        
+
         public static void Log(string text, bool flush = false) => AppendLog(text, flush);
 
         public static void Log(object obj, bool flush = false) => AppendLog($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff zzz}] {obj}", flush);

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Linux: `./LocalAdmin [port] [arguments] [-- arguments passthrough]`
 | --noAutoFlush | -n | Disables auto flush of LocalAdmin log files.<br>**Not compatible with --noLogs argument.** |
 | --restartsLimit |  | Specifies a limit of auto-restarts in a specified time window.<br>Setting this argument to 0 disables auto-restarts.<br>Setting this argument to -1 disables the limit.<br>*Default value: 4* |
 | --restartsTimeWindow |  | Specifies a time window (in seconds) for the auto-restarts limit.<br>Setting this argument to 0 disables resetting the amount of auto-restarts after a specified amount of time.<br>*Default value: 480* |
+| --logLengthLimit |  | Specifies the limit of characters in LocalAdmin log file.<br>Suffixes `k`, `M`, `G` and `T` are supported, eg. `5G` is equal to `5000000000` characters.<br>Setting this argument to 0 disables the limit.<br>*Default value: 25G* |
+| --logEntriesLimit |  | Specifies the limit of entries in LocalAdmin log file.<br>Suffixes `k`, `M`, `G` and `T` are supported, eg. `5G` is equal to `5000000000` entries.<br>Setting this argument to 0 disables the limit.<br>*Default value: 10G* |


### PR DESCRIPTION
This Merge Request introduces logging limits to prevent creating huge log files (eg. full of exceptions from a plugin).

Startup arguments `--logLengthLimit` and `--logEntriesLimit` have been introduced.