### PR TITLE
Updated `#pragma warning disable` in JsonGenerated.cs.

### DIFF
--- a/JSON/JsonGenerated.cs
+++ b/JSON/JsonGenerated.cs
@@ -1,7 +1,4 @@
-﻿#pragma warning disable 618
-#pragma warning disable 612
-#pragma warning disable 414
-#pragma warning disable 168
+﻿#pragma warning disable
 
 namespace Utf8Json.Resolvers
 {


### PR DESCRIPTION
Updated `#pragma warning disable` in JsonGenerated.cs.

This stops IDEs like Visual Studio, VSCode, Rider & more from showing a potential null reference.