### PR TITLE
Added options to disable LA setting the terminal title

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 charset = utf-8
-end_of_line = lf
+end_of_line = crlf
 
 [*.cs]
 insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 
 [*.cs]
 insert_final_newline = false

--- a/Core/ConfigWizard.cs
+++ b/Core/ConfigWizard.cs
@@ -47,6 +47,7 @@ public static class ConfigWizard
         }
 
         LocalAdmin.Configuration.RestartOnCrash = BoolInput("Should the server be automatically restarted after a crash?");
+        LocalAdmin.Configuration.SetTerminalTitle = BoolInput("Should the LocalAdmin status be written in the terminal title?");
         LocalAdmin.Configuration.LaLiveViewUseUtc = !BoolInput("Should timestamps in the LocalAdmin live view use server timezone (otherwise UTC time will be use)?");
 
         string? withoutTimezone = null;

--- a/Core/ConfigWizard.cs
+++ b/Core/ConfigWizard.cs
@@ -47,6 +47,7 @@ public static class ConfigWizard
         }
 
         LocalAdmin.Configuration.RestartOnCrash = BoolInput("Should the server be automatically restarted after a crash?");
+        LocalAdmin.Configuration.EnableHeartbeat = BoolInput("Should LocalAdmin attempt to detect silent crashes using heartbeat monitoring?");
         LocalAdmin.Configuration.SetTerminalTitle = BoolInput("Should the LocalAdmin status be written in the terminal title?");
         LocalAdmin.Configuration.LaLiveViewUseUtc = !BoolInput("Should timestamps in the LocalAdmin live view use server timezone (otherwise UTC time will be use)?");
 

--- a/Core/LocalAdmin.cs
+++ b/Core/LocalAdmin.cs
@@ -60,7 +60,7 @@ public sealed class LocalAdmin : IDisposable
     internal static Config? Configuration;
     internal static DataJson? DataJson;
     internal static string BaseWindowTitle = $"LocalAdmin v. {VersionString}";
-    internal static bool NoSetCursor, PrintControlMessages, AutoFlush = true, EnableLogging = true, NoPadding, DismissPluginsSecurityWarning;
+    internal static bool NoSetCursor, PrintControlMessages, AutoFlush = true, EnableLogging = true, NoPadding, DismissPluginsSecurityWarning, NoTerminalTitle;
 
     internal ShutdownAction ExitAction = ShutdownAction.Crash;
     internal bool DisableExitActionSignals;
@@ -116,8 +116,6 @@ public sealed class LocalAdmin : IDisposable
     internal async Task Start(string[] args)
     {
         Singleton = this;
-        Console.Title = BaseWindowTitle;
-
         HeartbeatStopwatch.Reset();
 
         if (!PathManager.CorrectPathFound && !args.Contains("--skipHomeCheck", StringComparer.Ordinal))
@@ -287,6 +285,9 @@ public sealed class LocalAdmin : IDisposable
                                         case 'a':
                                             NoPadding = true;
                                             break;
+                                        case 't':
+                                            NoTerminalTitle = true;
+                                            break;
                                     }
                                 }
                             }
@@ -360,6 +361,10 @@ public sealed class LocalAdmin : IDisposable
 
                                     case "--logEntriesLimit":
                                         capture = CaptureArgs.LogEntriesLimit;
+                                        break;
+
+                                    case "--noTerminalTitle":
+                                        NoTerminalTitle = true;
                                         break;
 
                                     case "--":
@@ -470,6 +475,8 @@ public sealed class LocalAdmin : IDisposable
                 }
             }
 
+            SetTerminalTitle(BaseWindowTitle);
+
             if (reconfigure)
                 ConfigWizard.RunConfigWizard(useDefault);
 
@@ -562,7 +569,7 @@ public sealed class LocalAdmin : IDisposable
         Menu();
 
         BaseWindowTitle = $"LocalAdmin v. {VersionString} on port {GamePort}";
-        Console.Title = BaseWindowTitle;
+        SetTerminalTitle(BaseWindowTitle);
 
         Logger.Initialize();
 
@@ -1131,5 +1138,16 @@ public sealed class LocalAdmin : IDisposable
     ~LocalAdmin()
     {
         Exit(0);
+    }
+
+    /// <summary>
+    ///     Sets the terminal title if not disabled in the config or by command line arguments
+    /// </summary>
+    public static void SetTerminalTitle(string terminalTitle)
+    {
+        if (!NoTerminalTitle && (Configuration?.SetTerminalTitle ?? false))
+        {
+            Console.Title = terminalTitle;
+        }
     }
 }

--- a/Core/TcpServer.cs
+++ b/Core/TcpServer.cs
@@ -139,11 +139,11 @@ public class TcpServer
                                     break;
 
                                 case OutputCodes.IdleEnter:
-                                    Console.Title = "[IDLE] " + LocalAdmin.BaseWindowTitle;
+                                    LocalAdmin.SetTerminalTitle("[IDLE] " + LocalAdmin.BaseWindowTitle);
                                     break;
 
                                 case OutputCodes.IdleExit:
-                                    Console.Title = LocalAdmin.BaseWindowTitle;
+                                    LocalAdmin.SetTerminalTitle(LocalAdmin.BaseWindowTitle);
                                     break;
 
                                 case OutputCodes.ExitActionReset:

--- a/IO/Config.cs
+++ b/IO/Config.cs
@@ -10,6 +10,7 @@ public class Config
 
     public bool RestartOnCrash = true;
     public bool EnableHeartbeat = true;
+    public bool SetTerminalTitle = true;
     public bool LaLiveViewUseUtc;
 
     public bool LaShowStdoutStderr;
@@ -43,6 +44,9 @@ public class Config
 
         sb.Append("enable_heartbeat: ");
         sb.AppendLine(EnableHeartbeat.ToString().ToLowerInvariant());
+
+        sb.Append("set_terminal_title: ");
+        sb.AppendLine(SetTerminalTitle.ToString().ToLowerInvariant());
 
         sb.Append("la_live_view_use_utc: ");
         sb.AppendLine(LaLiveViewUseUtc.ToString().ToLowerInvariant());
@@ -128,6 +132,10 @@ public class Config
 
                 case "enable_heartbeat" when bool.TryParse(sp[1], out var b):
                     cfg.EnableHeartbeat = b;
+                    break;
+
+                case "set_terminal_title" when bool.TryParse(sp[1], out var b):
+                    cfg.SetTerminalTitle = b;
                     break;
 
                 case "la_live_view_use_utc" when bool.TryParse(sp[1], out var b):
@@ -237,6 +245,7 @@ public class Config
 
         sb.AppendLine(RestartOnCrash ? "- Server will be automatically restarted after a crash." : "- Server will NOT be automatically restarted after a crash.");
         sb.AppendLine(EnableHeartbeat ? "- LocalAdmin will attempt to detect silent server crashes (heartbeat enabled)." : "- LocalAdmin will NOT attempt to detect silent server crashes (heartbeat DISABLED).");
+        sb.AppendLine(SetTerminalTitle ? "- LocalAdmin will attempt to show its current status in your terminal title." : "- LocalAdmin will NOT attempt to show its current status in your terminal title.");
         sb.AppendLine(LaLiveViewUseUtc ? "- LocalAdmin live view will use UTC timezone." : "- LocalAdmin live view will use local timezone.");
         sb.AppendLine($"- LocalAdmin live will use the following timestamp format: {LaLiveViewTimeFormat}");
         sb.AppendLine($"- UTC timezone will be displayed as \"{(LaLogsUseZForUtc ? "Z" : "+00:00")}\".");

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Linux: `./LocalAdmin [port] [arguments] [-- arguments passthrough]`
 | --noLogs | -l | Disables LocalAdmin logging. |
 | --noAutoFlush | -n | Disables auto flush of LocalAdmin log files.<br>**Not compatible with --noLogs argument.** |
 | --noAlign | -a | Disables multiline log entries alignment. |
-| ----noTerminalTitle | -t | Disables LocalAdmin status in the Terminal title. |
+| --noTerminalTitle | -t | Disables LocalAdmin status in the terminal title. |
 | --dismissPluginManagerSecurityWarning | | Dismisses Plugin Manager security warning. |
 | --disableTrueColor | | Disables True Color output. |
 | --skipHomeCheck | | Skips `home` env var checking on startup (linux only). |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Linux: `./LocalAdmin [port] [arguments] [-- arguments passthrough]`
 | --noLogs | -l | Disables LocalAdmin logging. |
 | --noAutoFlush | -n | Disables auto flush of LocalAdmin log files.<br>**Not compatible with --noLogs argument.** |
 | --noAlign | -a | Disables multiline log entries alignment. |
+| ----noTerminalTitle | -t | Disables LocalAdmin status in the Terminal title. |
 | --dismissPluginManagerSecurityWarning | | Dismisses Plugin Manager security warning. |
 | --disableTrueColor | | Disables True Color output. |
 | --skipHomeCheck | | Skips `home` env var checking on startup (linux only). |


### PR DESCRIPTION
Also fixed the line endings setting in the .editorconfig stating `crlf` while all the files in this repo have `lf` line endings.

Also fixed the config wizard not asking about the heartbeat monitoring setting.