### PR TITLE
Fixed line endings setting in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 
 [*.cs]
 insert_final_newline = false


### PR DESCRIPTION
All files in the repo have LF line endings but the editorconfig is set to CR/LF, I fix.