### PR TITLE
Move `laargs.txt` to more suitable location.

### DIFF
--- a/Core/Program.cs
+++ b/Core/Program.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Threading.Tasks;
 
 namespace LocalAdmin.V2.Core;
@@ -15,7 +14,6 @@ internal static class Program
         while (true)
         {
             using var la = new LocalAdmin();
-
             await la.Start(StartupArgManager.MergeStartupArgs(args));
         }
         // ReSharper disable once FunctionNeverReturns

--- a/Core/Program.cs
+++ b/Core/Program.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading.Tasks;
 
 namespace LocalAdmin.V2.Core;
@@ -14,6 +15,10 @@ internal static class Program
         while (true)
         {
             using var la = new LocalAdmin();
+
+            if (File.Exists("laargs.txt"))
+                StartupArgManager.MigrateArgsFile();
+
             await la.Start(StartupArgManager.MergeStartupArgs(args));
         }
         // ReSharper disable once FunctionNeverReturns

--- a/Core/Program.cs
+++ b/Core/Program.cs
@@ -16,9 +16,6 @@ internal static class Program
         {
             using var la = new LocalAdmin();
 
-            if (File.Exists("laargs.txt"))
-                StartupArgManager.MigrateArgsFile();
-
             await la.Start(StartupArgManager.MergeStartupArgs(args));
         }
         // ReSharper disable once FunctionNeverReturns

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -44,26 +44,12 @@ namespace LocalAdmin.V2.Core
         {
             const string OldFileLocation = "laargs.txt";
 
-            if (!File.Exists(OldFileLocation))
-                return;
-
-            if (File.Exists(StartupArgsPath))
+            if (!File.Exists(StartupArgsPath))
             {
-                bool IsArgsFileEmpty = string.IsNullOrEmpty(File.ReadAllText(StartupArgsPath));
-
-                if (IsArgsFileEmpty)
-                {
-                    File.Delete(StartupArgsPath);
-                    File.Move(OldFileLocation, StartupArgsPath);
-                }
+                if (!File.Exists(OldFileLocation))
+                    return;
                 else
-                {
-                    File.Delete(OldFileLocation);
-                }
-            }
-            else
-            {
-                File.Move(OldFileLocation, StartupArgsPath);
+                    File.Move(OldFileLocation, StartupArgsPath);
             }
         }
     }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -43,21 +43,11 @@ namespace LocalAdmin.V2.Core
             {
                 string OldFileLocation = "laargs.txt";
 
-                if (!File.Exists(StartupArgsPath))
-                {
-                    Console.WriteLine("File No Exist!");
-                    return;
-                }
+                if (!File.Exists(StartupArgsPath)) { return; }
                 if (string.IsNullOrEmpty(File.ReadAllText(OldFileLocation)) || string.IsNullOrWhiteSpace(File.ReadAllText(OldFileLocation)))
-                {
-                    Console.WriteLine("File in old location but empty.");
                     File.Delete(OldFileLocation);
-                }
-                Console.WriteLine("File in old location.");
 
-                // Deletes the laargs.txt in the new location which basically screws the Move operation.
                 File.Delete(StartupArgsPath);
-
                 File.WriteAllText(StartupArgsPath, File.ReadAllText(OldFileLocation));
                 File.Delete(OldFileLocation);
                 
@@ -65,9 +55,7 @@ namespace LocalAdmin.V2.Core
             }
             catch (Exception ex)
             {
-                // I have a massive skill issue and can't make this work without needing a try block. I am soley to blame.
                 ConsoleUtil.WriteLine($"An error occured while trying to migrate laargs.txt: {ex}", ConsoleColor.Red);
-                Console.ReadKey();
             }
         }
     }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -42,24 +42,22 @@ namespace LocalAdmin.V2.Core
 
         private static void MigrateArgsFile()
         {
-            try
-            {
-                const string OldFileLocation = "laargs.txt";
+            const string ObsoleteFile = "laargs.txt";
 
-                if (!File.Exists(StartupArgsPath))
-                {
-                    if (!File.Exists(OldFileLocation))
-                        return;
-                    else
-                        File.Move(OldFileLocation, StartupArgsPath);
-                }
-                else
-                    File.Delete(OldFileLocation);
-            }
-            catch (Exception ex)
+            if (File.Exists(ObsoleteFile) && string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
             {
-                ConsoleUtil.WriteLine($"An error occured while trying to migrate 'laargs.txt': {ex}");
+                File.Delete(ObsoleteFile);
+                return;
             }
+
+            if (File.Exists(StartupArgsPath))
+            {
+                ConsoleUtil.WriteLine("Unable to migrate your old laargs config. Aborting...");
+                return;
+            }
+
+            File.Move(ObsoleteFile, StartupArgsPath);
+            ConsoleUtil.WriteLine("Migrated your old laargs config.");
         }
     }
 }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -62,7 +62,9 @@ namespace LocalAdmin.V2.Core
                 }
             }
             else
+            {
                 File.Move(OldFileLocation, StartupArgsPath);
+            }
         }
     }
 }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -40,16 +40,23 @@ namespace LocalAdmin.V2.Core
             }
         }
 
-        public static void MigrateArgsFile()
+        private static void MigrateArgsFile()
         {
-            const string OldFileLocation = "laargs.txt";
-
-            if (!File.Exists(StartupArgsPath))
+            try
             {
-                if (!File.Exists(OldFileLocation))
-                    return;
-                else
-                    File.Move(OldFileLocation, StartupArgsPath);
+                const string OldFileLocation = "laargs.txt";
+
+                if (!File.Exists(StartupArgsPath))
+                {
+                    if (!File.Exists(OldFileLocation))
+                        return;
+                    else
+                        File.Move(OldFileLocation, StartupArgsPath);
+                }
+            }
+            catch (Exception ex)
+            {
+                ConsoleUtil.WriteLine($"An error occured while trying to migrate 'laargs.txt': {ex}");
             }
         }
     }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -53,6 +53,8 @@ namespace LocalAdmin.V2.Core
                     else
                         File.Move(OldFileLocation, StartupArgsPath);
                 }
+                else
+                    File.Delete(OldFileLocation);
             }
             catch (Exception ex)
             {

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -36,5 +36,39 @@ namespace LocalAdmin.V2.Core
                 return startupArgs.ToArray();
             }
         }
+
+        public static void MigrateArgsFile()
+        {
+            try
+            {
+                string OldFileLocation = "laargs.txt";
+
+                if (!File.Exists(StartupArgsPath))
+                {
+                    Console.WriteLine("File No Exist!");
+                    return;
+                }
+                if (string.IsNullOrEmpty(File.ReadAllText(OldFileLocation)) || string.IsNullOrWhiteSpace(File.ReadAllText(OldFileLocation)))
+                {
+                    Console.WriteLine("File in old location but empty.");
+                    File.Delete(OldFileLocation);
+                }
+                Console.WriteLine("File in old location.");
+
+                // Deletes the laargs.txt in the new location which basically screws the Move operation.
+                File.Delete(StartupArgsPath);
+
+                File.WriteAllText(StartupArgsPath, File.ReadAllText(OldFileLocation));
+                File.Delete(OldFileLocation);
+                
+                return;
+            }
+            catch (Exception ex)
+            {
+                // I have a massive skill issue and can't make this work without needing a try block. I am soley to blame.
+                ConsoleUtil.WriteLine($"An error occured while trying to migrate laargs.txt: {ex}", ConsoleColor.Red);
+                Console.ReadKey();
+            }
+        }
     }
 }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -49,22 +49,27 @@ namespace LocalAdmin.V2.Core
                 if (File.Exists(ObsoleteFile) && string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
                 {
                     File.Delete(ObsoleteFile);
-                    ConsoleUtil.WriteLine("Obsolete configuration file 'laargs.txt' is empty and has been deleted.");
+                    ConsoleUtil.WriteLine("Obsolete configuration file 'laargs.txt' is empty and has been deleted.", ConsoleColor.Gray);
                     return;
                 }
 
                 if (File.Exists(StartupArgsPath))
+                    return;
+
+                try
                 {
-                    ConsoleUtil.WriteLine("Unable to migrate your old 'laargs' configuration. The destination file already exists.");
+                    File.Move(ObsoleteFile, StartupArgsPath);
+                }
+                catch
+                {
                     return;
                 }
 
-                File.Move(ObsoleteFile, StartupArgsPath);
-                ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.");
+                ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.", ConsoleColor.DarkGreen);
             }
             catch (Exception ex)
             {
-                ConsoleUtil.WriteLine($"An error occurred during migration: {ex}");
+                ConsoleUtil.WriteLine($"An error occurred during migration: {ex}", ConsoleColor.Yellow);
             }
         }
     }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -59,11 +59,8 @@ namespace LocalAdmin.V2.Core
                 if (File.Exists(StartupArgsPath))
                     return;
 
-                if (File.Exists(ObsoleteFile) && !File.Exists(StartupArgsPath))
-                {
-                    File.Move(ObsoleteFile, StartupArgsPath);
-                    ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.", ConsoleColor.DarkGreen);
-                }
+                File.Move(ObsoleteFile, StartupArgsPath);
+                ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.", ConsoleColor.DarkGreen);
             }
             catch (Exception ex)
             {

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -11,8 +11,8 @@ namespace LocalAdmin.V2.Core
         /// <summary>
         /// Path to startup arguments file.
         /// </summary>
-        private const string StartupArgsPath = "laargs.txt";
-
+        private static string StartupArgsPath = Path.Combine(PathManager.GameUserDataRoot, "config", "laargs.txt");
+        
         /// <summary>
         /// Merges Command-line arguments and arguments in <paramref name="cmdArgs"/>
         /// </summary>

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -12,6 +12,7 @@ namespace LocalAdmin.V2.Core
         /// Path to startup arguments file.
         /// </summary>
         private static readonly string StartupArgsPath = Path.Combine(PathManager.ConfigPath, "laargs.txt");
+
         /// <summary>
         /// Merges Command-line arguments and arguments in <paramref name="cmdArgs"/>
         /// </summary>
@@ -19,6 +20,8 @@ namespace LocalAdmin.V2.Core
         /// <returns>Merged Arguments</returns>
         public static string[] MergeStartupArgs(IEnumerable<string> cmdArgs)
         {
+            MigrateArgsFile();
+
             List<string> startupArgs = new List<string>();
             startupArgs.AddRange(cmdArgs);
 
@@ -39,24 +42,27 @@ namespace LocalAdmin.V2.Core
 
         public static void MigrateArgsFile()
         {
-            try
-            {
-                string OldFileLocation = "laargs.txt";
+            const string OldFileLocation = "laargs.txt";
 
-                if (!File.Exists(StartupArgsPath)) { return; }
-                if (string.IsNullOrEmpty(File.ReadAllText(OldFileLocation)) || string.IsNullOrWhiteSpace(File.ReadAllText(OldFileLocation)))
-                    File.Delete(OldFileLocation);
-
-                File.Delete(StartupArgsPath);
-                File.WriteAllText(StartupArgsPath, File.ReadAllText(OldFileLocation));
-                File.Delete(OldFileLocation);
-                
+            if (!File.Exists(OldFileLocation))
                 return;
-            }
-            catch (Exception ex)
+
+            if (File.Exists(StartupArgsPath))
             {
-                ConsoleUtil.WriteLine($"An error occured while trying to migrate laargs.txt: {ex}", ConsoleColor.Red);
+                bool IsArgsFileEmpty = string.IsNullOrEmpty(File.ReadAllText(StartupArgsPath));
+
+                if (IsArgsFileEmpty)
+                {
+                    File.Delete(StartupArgsPath);
+                    File.Move(OldFileLocation, StartupArgsPath);
+                }
+                else
+                {
+                    File.Delete(OldFileLocation);
+                }
             }
+            else
+                File.Move(OldFileLocation, StartupArgsPath);
         }
     }
 }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -44,20 +44,28 @@ namespace LocalAdmin.V2.Core
         {
             const string ObsoleteFile = "laargs.txt";
 
-            if (File.Exists(ObsoleteFile) && string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
+            try
             {
-                File.Delete(ObsoleteFile);
-                return;
-            }
+                if (File.Exists(ObsoleteFile) && string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
+                {
+                    File.Delete(ObsoleteFile);
+                    ConsoleUtil.WriteLine("Obsolete configuration file 'laargs.txt' is empty and has been deleted.");
+                    return;
+                }
 
-            if (File.Exists(StartupArgsPath))
+                if (File.Exists(StartupArgsPath))
+                {
+                    ConsoleUtil.WriteLine("Unable to migrate your old 'laargs' configuration. The destination file already exists.");
+                    return;
+                }
+
+                File.Move(ObsoleteFile, StartupArgsPath);
+                ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.");
+            }
+            catch (Exception ex)
             {
-                ConsoleUtil.WriteLine("Unable to migrate your old laargs config. Aborting...");
-                return;
+                ConsoleUtil.WriteLine($"An error occurred during migration: {ex}");
             }
-
-            File.Move(ObsoleteFile, StartupArgsPath);
-            ConsoleUtil.WriteLine("Migrated your old laargs config.");
         }
     }
 }

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -11,8 +11,7 @@ namespace LocalAdmin.V2.Core
         /// <summary>
         /// Path to startup arguments file.
         /// </summary>
-        private static string StartupArgsPath = Path.Combine(PathManager.GameUserDataRoot, "config", "laargs.txt");
-        
+        private static readonly string StartupArgsPath = Path.Combine(PathManager.ConfigPath, "laargs.txt");
         /// <summary>
         /// Merges Command-line arguments and arguments in <paramref name="cmdArgs"/>
         /// </summary>

--- a/Core/StartupArgManager.cs
+++ b/Core/StartupArgManager.cs
@@ -46,7 +46,10 @@ namespace LocalAdmin.V2.Core
 
             try
             {
-                if (File.Exists(ObsoleteFile) && string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
+                if (!File.Exists(ObsoleteFile))
+                    return;
+
+                if (string.IsNullOrWhiteSpace(File.ReadAllText(ObsoleteFile)))
                 {
                     File.Delete(ObsoleteFile);
                     ConsoleUtil.WriteLine("Obsolete configuration file 'laargs.txt' is empty and has been deleted.", ConsoleColor.Gray);
@@ -56,16 +59,11 @@ namespace LocalAdmin.V2.Core
                 if (File.Exists(StartupArgsPath))
                     return;
 
-                try
+                if (File.Exists(ObsoleteFile) && !File.Exists(StartupArgsPath))
                 {
                     File.Move(ObsoleteFile, StartupArgsPath);
+                    ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.", ConsoleColor.DarkGreen);
                 }
-                catch
-                {
-                    return;
-                }
-
-                ConsoleUtil.WriteLine("Successfully migrated your old 'laargs' configuration.", ConsoleColor.DarkGreen);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This moves the `laargs.txt` file from the root directory of the application. (Likely in a protected folder.) to a user based one. Allowing different users to activate different settings.

Fixes #82.