### PR TITLE
LabAPI support for Plugins Manager

### DIFF
--- a/PluginsManager/PluginInstaller.cs
+++ b/PluginsManager/PluginInstaller.cs
@@ -26,8 +26,8 @@ internal static class PluginInstaller
             ? null
             : new AuthenticationHeaderValue("Bearer", Core.LocalAdmin.DataJson.GitHubPersonalAccessToken);
 
-    internal static string PluginsPath(string port) => $"{PathManager.GameUserDataRoot}PluginAPI{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}{port}{Path.DirectorySeparatorChar}";
-    private static string DependenciesPath(string port) => $"{PluginsPath(port)}dependencies{Path.DirectorySeparatorChar}";
+    internal static string PluginsPath(string port) => $"{PathManager.GameUserDataRoot}LabAPI{Path.DirectorySeparatorChar}plugins{Path.DirectorySeparatorChar}{port}{Path.DirectorySeparatorChar}";
+    private static string DependenciesPath(string port) => $"{PathManager.GameUserDataRoot}LabAPI{Path.DirectorySeparatorChar}dependencies{Path.DirectorySeparatorChar}{port}{Path.DirectorySeparatorChar}";
     private static string TempPath(ushort port) => $"{PathManager.GameUserDataRoot}internal{Path.DirectorySeparatorChar}LA Temp{Path.DirectorySeparatorChar}{port}{Path.DirectorySeparatorChar}";
 
     internal const uint DefaultLockTime = 30000;


### PR DESCRIPTION
This PR addresses #98

Replaced `plugins` and `dependencies` paths with new LabAPI versions. Didn't see any reason to keep the old paths, since NwPluginAPI is no longer supported.

Tested plugin manager subcommands on local server instance.